### PR TITLE
[Feature] 탈퇴 회원 기간 만료 후 정보 삭제

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    implementation 'org.modelmapper:modelmapper:3.1.1'
+    implementation 'com.konghq:unirest-java:3.13.6'
 //    implementation 'ch.qos.logback:logback-classic:1.2.3'
 }
 

--- a/src/main/java/respring/dorering/rest/admin/config/ApiKeyConfiguration.java
+++ b/src/main/java/respring/dorering/rest/admin/config/ApiKeyConfiguration.java
@@ -1,0 +1,15 @@
+package respring.dorering.rest.admin.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ApiKeyConfiguration {
+
+    @Value("${elevenlabs-api.key}")
+    private String elevenKey;
+
+    public String getElevenKey() {
+        return elevenKey;
+    }
+}

--- a/src/main/java/respring/dorering/rest/admin/controller/AdminController.java
+++ b/src/main/java/respring/dorering/rest/admin/controller/AdminController.java
@@ -1,0 +1,44 @@
+package respring.dorering.rest.admin.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import respring.dorering.rest.admin.dto.VoiceDTO;
+import respring.dorering.rest.admin.service.AdminService;
+import respring.dorering.rest.auth.exception.CustomException;
+
+import java.util.List;
+
+@Slf4j
+@RequestMapping("/")
+@RestController
+@RequiredArgsConstructor
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @GetMapping("/expVoice")
+    public ResponseEntity<List<VoiceDTO>> selectAllExpiredVoices(){
+
+        try {
+            List<VoiceDTO> allExpVoices = adminService.selectAllExpiredVoices();
+            log.info("[AdminController] selectAllExpiredVoices allExpVoices : " + allExpVoices);
+            return ResponseEntity.ok(allExpVoices);
+        } catch (Exception e) {
+            log.error("[AdminController] selectAllExpiredVoices error : " + e);
+            throw new CustomException("An error occurs at AdminController selectAllExpiredVoices");
+        }
+    }
+
+    @DeleteMapping("/deleteVoice/{voiceId}")
+    public ResponseEntity<?> deleteExpVoiceId(@PathVariable String voiceId){
+        boolean isSuccess = adminService.deleteExpVoiceId(voiceId);
+        if(isSuccess) {
+            log.info("[AdminController] deleteExpVoiceId : Voice ID successfully deleted.");
+            return ResponseEntity.ok().body("Voice ID successfully deleted.");
+        } else {
+            throw new CustomException("An error occurs at AdminController deleteExpVoiceId");
+        }
+    }
+}

--- a/src/main/java/respring/dorering/rest/admin/dto/VoiceDTO.java
+++ b/src/main/java/respring/dorering/rest/admin/dto/VoiceDTO.java
@@ -1,0 +1,13 @@
+package respring.dorering.rest.admin.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@ToString
+public class VoiceDTO {
+    private int no;
+    private String voiceId;
+}

--- a/src/main/java/respring/dorering/rest/admin/entity/Voice.java
+++ b/src/main/java/respring/dorering/rest/admin/entity/Voice.java
@@ -1,0 +1,30 @@
+package respring.dorering.rest.admin.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor
+@Getter
+@ToString
+@Entity
+@Table(name = "exp_voice_id")
+public class Voice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "no")
+    private int no;
+
+    @Column(name = "voice_id", unique = true)
+    private String voiceId;
+
+    @Builder
+    public Voice(Long no, String voiceId) {
+        this.no = no;
+        this.voiceId = voiceId;
+    }
+
+}

--- a/src/main/java/respring/dorering/rest/admin/repository/AdminRepository.java
+++ b/src/main/java/respring/dorering/rest/admin/repository/AdminRepository.java
@@ -1,0 +1,8 @@
+package respring.dorering.rest.admin.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import respring.dorering.rest.admin.entity.Voice;
+
+public interface AdminRepository extends JpaRepository<Voice, Integer> {
+    void deleteByVoiceId(String voiceId);
+}

--- a/src/main/java/respring/dorering/rest/admin/service/AdminService.java
+++ b/src/main/java/respring/dorering/rest/admin/service/AdminService.java
@@ -1,0 +1,58 @@
+package respring.dorering.rest.admin.service;
+
+import kong.unirest.HttpResponse;
+import kong.unirest.Unirest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import respring.dorering.rest.admin.config.ApiKeyConfiguration;
+import respring.dorering.rest.admin.dto.VoiceDTO;
+import respring.dorering.rest.admin.entity.Voice;
+import respring.dorering.rest.admin.repository.AdminRepository;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final ModelMapper modelMapper;
+    private ApiKeyConfiguration apiConfiguration;
+
+    public List<VoiceDTO> selectAllExpiredVoices() {
+        List<Voice> allExpVoices = adminRepository.findAll();
+
+        allExpVoices.sort(Comparator.comparingInt(Voice::getNo));
+        Collections.reverse(allExpVoices);
+
+        return allExpVoices.stream()
+                .map(list -> modelMapper.map(list, VoiceDTO.class))
+                .collect(Collectors.toList());
+    }
+
+    public boolean deleteExpVoiceId(String voiceId) {
+        try {
+            HttpResponse<String> response = Unirest.delete("https://api.elevenlabs.io/v1/voices/" + voiceId)
+                    .header("xi-api-key", apiConfiguration.getElevenKey())
+                    .asString();
+            if(response.getStatusText().equals("ok")){
+                adminRepository.deleteByVoiceId(voiceId);
+                return true;
+            } else {
+                log.info("[AdminService] deleteExpVoiceId error at HttpResponse");
+                return false;
+            }
+        } catch (Exception e) {
+            log.error("[AdminService] deleteExpVoiceId error : " + e);
+            return false;
+        }
+    }
+}

--- a/src/main/java/respring/dorering/rest/config/BeanConfiguration.java
+++ b/src/main/java/respring/dorering/rest/config/BeanConfiguration.java
@@ -1,0 +1,22 @@
+package respring.dorering.rest.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class BeanConfiguration {
+
+    @Bean
+    public ModelMapper modelMapper(){
+        ModelMapper modelMapper = new ModelMapper();
+
+        modelMapper.getConfiguration().setAmbiguityIgnored(true);
+
+        modelMapper.getConfiguration()
+                .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
+                .setFieldMatchingEnabled(true);
+
+        return modelMapper;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,3 +19,6 @@ jwt:
   key: eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9
   time: 86400000
   secret: eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0
+
+elevenlabs-api:
+  key: "2fae9a043baf5a1c42b9d7697c20e8ff"


### PR DESCRIPTION
## 작업 분류
* * *
- 

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
* * *
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경변수, 빌드 관련 코드 업데이트
- [ ] 기타 수정

## 개요
* * *
- 탈퇴 한달 지난 회원 정보(보이스아이디) 삭제

## 변경 사항
* * *
- 이벤트 생성(delete_voice_code 테이블에 해당하는 voice id 삽입)
- 프론트에서 API 요청 보내면 관련 테이블 조회해서 리스트 반환
- 삭제 API 요청 받으면 보이스아이디 삭제(elevenlabs 삭제 요청 날린 후 db에서도 삭제)

## 코드 리뷰시 참고 사항
* * *


## 테스트 결과
* * *
- 아직 테스트 전입니다.
## 요청 사항
* * *

